### PR TITLE
YNU-LMS-Extensionからのリクエストであることを分かるようにする

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -125,7 +125,7 @@ async function fetchHomeworks(uniqueLecIds) {
         const lecId = uniqueLecIds[i];
         const url = "https://lms.ynu.ac.jp/lms/homeHoml/linkKougi?kougiId=" + lecId;
 
-        const response = await fetch(url);
+        const response = await fetch(url, { headers: { 'YNU-LMS-Extension': '1.0.1' }});
         const htmlString = await response.text();
 
         const parser = new DOMParser();


### PR DESCRIPTION
リクエストヘッダーにYNU-LMS-Extensionの情報を付与することで、
サーバー側でrate limitかけたい時に利用できるようにしてみました。

こんな感じでヘッダーが付与されます 👍 
<img width="1022" alt="スクリーンショット 2021-10-29 16 07 38" src="https://user-images.githubusercontent.com/866589/139395284-ba15382b-c429-4398-8517-1d383ad32fb3.png">
